### PR TITLE
Remove global variables

### DIFF
--- a/lib/industrialist/manufacturable.rb
+++ b/lib/industrialist/manufacturable.rb
@@ -4,17 +4,20 @@ module Industrialist
   module Manufacturable
     def self.included(base)
       base.extend ClassMethods
+      base.instance_variable_set(:@factory, Industrialist::Factory.new)
     end
 
     module ClassMethods
-      @@factory = Industrialist::Factory.new
+      def inherited(base)
+        base.instance_variable_set(:@factory, @factory)
+      end
 
       def create_factory(identifier)
-        Object.const_set(identifier, @@factory)
+        Object.const_set(identifier, @factory)
       end
 
       def corresponds_to(key)
-        @@factory.register(key, self)
+        @factory.register(key, self)
       end
     end
   end

--- a/spec/lib/industrialist/manufacturable_spec.rb
+++ b/spec/lib/industrialist/manufacturable_spec.rb
@@ -1,12 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe Industrialist::Manufacturable do
-  before do
+  def undefine_constants(*consts)
+    consts.each { |const| Object.send(:remove_const, const) }
+  end
+
+  around do |example|
     class Automobile
       include Industrialist::Manufacturable
       create_factory :AutomobileFactory
     end
+    class Book
+      include Industrialist::Manufacturable
+      create_factory :BookFactory
+    end
+    example.run
+    undefine_constants(:Automobile, :Book, :AutomobileFactory, :BookFactory)
   end
+
 
   describe '.factory_name' do
     it 'assigns the provided name to the factory instance' do
@@ -15,14 +26,21 @@ RSpec.describe Industrialist::Manufacturable do
   end
 
   describe '.corresponds_to' do
-    before do
-      class Sedan < Automobile
-        corresponds_to :sedan
-      end
+    around do |example|
+      class Sedan     < Automobile; corresponds_to :sedan    ; end
+      class Paperback < Book      ; corresponds_to :paperback; end
+      example.run
+      undefine_constants(:Sedan, :Paperback)
     end
 
     it 'registers the class under the provided key' do
       expect(AutomobileFactory.registry[:sedan]).to equal(Sedan)
+      expect(BookFactory.registry[:paperback]).to equal(Paperback)
+    end
+
+    it 'registers the class only under the provided key' do
+      expect(AutomobileFactory.registry[:paperback]).to be_nil
+      expect(BookFactory.registry[:sedan]).to be_nil
     end
   end
 end


### PR DESCRIPTION
Currently all factories share the same `@@factory` global variable. This allows each factory to maintain a separate registry. Feel free to discard this PR and just treat this as a bug report. :)