### PR TITLE
Ensures each manufacturable class gets a different factory instance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    industrialist (0.1.0)
+    industrialist (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/industrialist/manufacturable.rb
+++ b/lib/industrialist/manufacturable.rb
@@ -1,20 +1,30 @@
 require 'industrialist/factory'
+require 'industrialist/warning_helper'
 
 module Industrialist
   module Manufacturable
+    extend WarningHelper
+
+    ALREADY_INCLUDED_WARNING_MESSAGE = 'warning: a factory is already defined on this class hierarchy'.freeze
+
     def self.included(base)
+      warning(ALREADY_INCLUDED_WARNING_MESSAGE) if base.class_variable_defined?(:@@factory)
+
       base.extend ClassMethods
+      base.class_variable_set(:@@factory, Industrialist::Factory.new)
     end
 
     module ClassMethods
-      @@factory = Industrialist::Factory.new
-
       def create_factory(identifier)
-        Object.const_set(identifier, @@factory)
+        Object.const_set(identifier, factory)
       end
 
       def corresponds_to(key)
-        @@factory.register(key, self)
+        factory.register(key, self)
+      end
+
+      def factory
+        class_variable_get(:@@factory)
       end
     end
   end

--- a/lib/industrialist/version.rb
+++ b/lib/industrialist/version.rb
@@ -1,3 +1,3 @@
 module Industrialist
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.2.1'.freeze
 end

--- a/lib/industrialist/warning_helper.rb
+++ b/lib/industrialist/warning_helper.rb
@@ -1,0 +1,10 @@
+module Industrialist
+  module WarningHelper
+    def warning(message)
+      most_recent_caller = caller(2..2).first.split(':')
+      file_name = most_recent_caller[0]
+      line_number = most_recent_caller[1]
+      warn("#{file_name}:#{line_number}: #{message}")
+    end
+  end
+end

--- a/spec/lib/industrialist/manufacturable_spec.rb
+++ b/spec/lib/industrialist/manufacturable_spec.rb
@@ -1,28 +1,85 @@
 require 'spec_helper'
 
 RSpec.describe Industrialist::Manufacturable do
-  before do
+  before(:all) do
     class Automobile
       include Industrialist::Manufacturable
       create_factory :AutomobileFactory
     end
+    class Book
+      include Industrialist::Manufacturable
+      create_factory :BookFactory
+    end
   end
 
-  describe '.factory_name' do
+  describe '.included' do
+    let(:manufacturable_class) do
+      Class.new do
+        include Industrialist::Manufacturable
+        create_factory :AnimalFactory
+      end
+    end
+
+    before do
+      allow(described_class).to receive(:warn).and_call_original
+    end
+
+    context 'when the factory is NOT defined on the base class' do
+      before { manufacturable_class }
+
+      it 'does NOT warn' do
+        expect(described_class).not_to have_received(:warn)
+      end
+    end
+
+    context 'when the factory is defined on the base class' do
+      let(:child_of_manufacturable_class) do
+        Class.new(manufacturable_class) do
+          include Industrialist::Manufacturable
+        end
+      end
+
+      before { child_of_manufacturable_class }
+
+      it 'warns' do
+        expect(described_class).to have_received(:warn)
+      end
+    end
+  end
+
+  describe '.create_factory' do
     it 'assigns the provided name to the factory instance' do
       expect(AutomobileFactory).to be_an(Industrialist::Factory)
+    end
+
+    it 'assigns a different factory instance to each base class' do
+      expect(AutomobileFactory.object_id).not_to eq(BookFactory.object_id)
     end
   end
 
   describe '.corresponds_to' do
-    before do
+    before(:all) do
       class Sedan < Automobile
         corresponds_to :sedan
+      end
+      class Paperback < Book
+        corresponds_to :paperback
+      end
+      class Coupe < Automobile
+        corresponds_to :coupe
       end
     end
 
     it 'registers the class under the provided key' do
       expect(AutomobileFactory.registry[:sedan]).to equal(Sedan)
+      expect(AutomobileFactory.registry[:coupe]).to equal(Coupe)
+      expect(BookFactory.registry[:paperback]).to equal(Paperback)
+    end
+
+    it 'does NOT register the class in other factories' do
+      expect(AutomobileFactory.registry[:paperback]).to be_nil
+      expect(BookFactory.registry[:sedan]).to be_nil
+      expect(BookFactory.registry[:coupe]).to be_nil
     end
   end
 end


### PR DESCRIPTION
This fixes the following issue: https://github.com/entelo/industrialist/issues/8