### PR TITLE
Industrialist 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    industrialist (0.4.0)
+    industrialist (1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/example/airplanes/airplane.rb
+++ b/example/airplanes/airplane.rb
@@ -1,0 +1,7 @@
+class Airplane
+  extend Industrialist::Manufacturable
+
+  def info
+    puts self.class.name
+  end
+end

--- a/example/airplanes/airplane_factory.rb
+++ b/example/airplanes/airplane_factory.rb
@@ -1,0 +1,7 @@
+require_relative 'airplane'
+
+class AirplaneFactory
+  extend Industrialist::Factory
+
+  manufactures Airplane
+end

--- a/example/airplanes/f16_tomcat.rb
+++ b/example/airplanes/f16_tomcat.rb
@@ -1,0 +1,6 @@
+require_relative 'airplane'
+
+class F16Tomcat < Airplane
+  corresponds_to :f16
+  corresponds_to :tomcat
+end

--- a/example/airplanes/p51_mustang.rb
+++ b/example/airplanes/p51_mustang.rb
@@ -1,0 +1,6 @@
+require_relative 'airplane'
+
+class P51Mustang < Airplane
+  corresponds_to :p51
+  corresponds_to :mustang
+end

--- a/example/app.rb
+++ b/example/app.rb
@@ -1,0 +1,15 @@
+require 'industrialist'
+
+Industrialist.config do |config|
+  config.manufacturable_paths << "#{File.dirname(__FILE__)}/automobiles"
+  config.manufacturable_paths << "#{File.dirname(__FILE__)}/airplanes"
+end
+
+AutomobileFactory.build(:sedan).info
+AutomobileFactory.build(:convertible).info
+AutomobileFactory.build(:cabriolet).info
+
+AirplaneFactory.build(:f16).info
+AirplaneFactory.build(:tomcat).info
+AirplaneFactory.build(:p51).info
+AirplaneFactory.build(:mustang).info

--- a/example/automobiles/automobile.rb
+++ b/example/automobiles/automobile.rb
@@ -1,0 +1,7 @@
+class Automobile
+  extend Industrialist::Manufacturable
+
+  def info
+    puts self.class.name
+  end
+end

--- a/example/automobiles/automobile_factory.rb
+++ b/example/automobiles/automobile_factory.rb
@@ -1,0 +1,7 @@
+require_relative 'automobile'
+
+class AutomobileFactory
+  extend Industrialist::Factory
+
+  manufactures Automobile
+end

--- a/example/automobiles/convertible.rb
+++ b/example/automobiles/convertible.rb
@@ -1,0 +1,6 @@
+require_relative 'automobile'
+
+class Convertible < Automobile
+  corresponds_to :convertible
+  corresponds_to :cabriolet
+end

--- a/example/automobiles/sedan.rb
+++ b/example/automobiles/sedan.rb
@@ -1,0 +1,5 @@
+require_relative 'automobile'
+
+class Sedan < Automobile
+  corresponds_to :sedan
+end

--- a/lib/industrialist.rb
+++ b/lib/industrialist.rb
@@ -1,2 +1,5 @@
 require "industrialist/version"
+require "industrialist/config"
 require "industrialist/manufacturable"
+require "industrialist/factory"
+require 'industrialist/railtie' if defined?(Rails)

--- a/lib/industrialist/builder.rb
+++ b/lib/industrialist/builder.rb
@@ -1,0 +1,14 @@
+require 'industrialist/registrar'
+
+module Industrialist
+  class Builder
+    def self.build(type, key, *args)
+      klass = Registrar.value_for(type, key)
+      Object.const_get(klass.name)&.new(*args) unless klass.nil?
+    end
+  end
+
+  def self.build(*args)
+    Builder.build(*args)
+  end
+end

--- a/lib/industrialist/config.rb
+++ b/lib/industrialist/config.rb
@@ -1,0 +1,27 @@
+module Industrialist
+  class Config
+    class << self
+      attr_writer :require_method
+
+      def manufacturable_paths
+        @manufacturable_paths ||= []
+      end
+
+      def load_manufacturables
+        manufacturable_paths.each { |path| Dir["#{path}/**/*.rb"].each { |file| Kernel.public_send(require_method, file) } }
+      end
+
+      private
+
+      def require_method
+        @require_method || :require
+      end
+    end
+  end
+
+  def self.config
+    yield(Config)
+
+    Config.load_manufacturables
+  end
+end

--- a/lib/industrialist/factory.rb
+++ b/lib/industrialist/factory.rb
@@ -1,26 +1,15 @@
+require 'industrialist/builder'
+
 module Industrialist
-  class Factory
-    DEFAULT_KEY = :__manufacturable_default__
-
-    attr_reader :registry
-
-    def initialize
-      @registry = {}
-    end
-
-    def register(key, klass)
-      registry[factory_key(key)] = klass
+  module Factory
+    def manufactures(klass)
+      @type = Type.industrialize(klass)
     end
 
     def build(key, *args)
-      klass = registry[factory_key(key)] || registry[DEFAULT_KEY]
-      klass&.new(*args)
-    end
+      return if @type.nil?
 
-    private
-
-    def factory_key(key)
-      (key.respond_to?(:to_sym) && key.to_sym) || key
+      Builder.build(@type, key, *args)
     end
   end
 end

--- a/lib/industrialist/railtie.rb
+++ b/lib/industrialist/railtie.rb
@@ -1,0 +1,9 @@
+require 'industrialist/config'
+
+module Industrialist
+  class Railtie < Rails::Railtie
+    initializer "industrialist.configure_rails_initialization" do |app|
+      Industrialist::Config.require_method = app.config.eager_load ? :require : :require_dependency
+    end
+  end
+end

--- a/lib/industrialist/registrar.rb
+++ b/lib/industrialist/registrar.rb
@@ -1,0 +1,56 @@
+require 'industrialist/type'
+require 'industrialist/warning_helper'
+
+module Industrialist
+  class Registrar
+    DEFAULT_KEY = :__manufacturable_default__
+    REDEFINED_KEY_WARNING_MESSAGE = 'warning: overriding a previously registered class'.freeze
+    REDEFINED_DEFAULT_WARNING_MESSAGE = 'warning: overriding a previously registered default class'.freeze
+
+    class << self
+      def register(type, key, klass)
+        WarningHelper.warning(REDEFINED_KEY_WARNING_MESSAGE) if overriding?(type, key, klass)
+
+        registry[type][key] = klass
+      end
+
+      def register_default(type, klass)
+        WarningHelper.warning(REDEFINED_DEFAULT_WARNING_MESSAGE) if overriding?(type, DEFAULT_KEY, klass)
+
+        registry[type][DEFAULT_KEY] = klass
+      end
+
+      def value_for(type, key)
+        return unless registry.key?(type)
+
+        registry[type][key] || registry[type][DEFAULT_KEY]
+      end
+
+      def registered_types
+        registry.keys
+      end
+
+      def registered_keys(type)
+        registry[type].keys
+      end
+
+      private
+
+      def overriding?(type, key, klass)
+        !registry[type][key].nil? && registry[type][key].name != klass.name
+      end
+
+      def registry
+        @registry ||= Hash.new { |hash, key| hash[key] = {} }
+      end
+    end
+  end
+
+  def self.registered_types
+    Registrar.registered_types
+  end
+
+  def self.registered_keys(type)
+    Registrar.registered_keys(type)
+  end
+end

--- a/lib/industrialist/type.rb
+++ b/lib/industrialist/type.rb
@@ -1,0 +1,23 @@
+module Industrialist
+  class Type
+    def self.industrialize(klass)
+      str = klass.name
+      str = separate_lowercase_or_number_from_uppercase_letters(str)
+      str = separate_numbers_from_letters(str)
+      str = separate_last_consecutive_uppercase_letter_when_followed_by_lowercase_letter(str)
+      str.downcase.to_sym
+    end
+
+    def self.separate_lowercase_or_number_from_uppercase_letters(string)
+      string.gsub(/[a-z0-9][A-Z]+/) { |s| "#{s[0]}_#{s[1..-1]}" }
+    end
+
+    def self.separate_numbers_from_letters(string)
+      string.gsub(/[a-zA-Z][0-9]+/) { |s| "#{s[0]}_#{s[1..-1]}" }
+    end
+
+    def self.separate_last_consecutive_uppercase_letter_when_followed_by_lowercase_letter(string)
+      string.gsub(/[A-Z][A-Z]+[a-z]/) { |s| "#{s[0..-3]}_#{s[-2..-1]}" }
+    end
+  end
+end

--- a/lib/industrialist/version.rb
+++ b/lib/industrialist/version.rb
@@ -1,3 +1,3 @@
 module Industrialist
-  VERSION = '0.4.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/lib/industrialist/warning_helper.rb
+++ b/lib/industrialist/warning_helper.rb
@@ -1,10 +1,7 @@
 module Industrialist
   class WarningHelper
     def self.warning(message)
-      most_recent_caller = caller(2..2).first.split(':')
-      file_name = most_recent_caller[0]
-      line_number = most_recent_caller[1]
-      warn("#{file_name}:#{line_number}: #{message}")
+      warn("#{caller(3..3).first}: #{message}")
     end
   end
 end

--- a/spec/lib/industrialist/builder_spec.rb
+++ b/spec/lib/industrialist/builder_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+RSpec.describe Industrialist::Builder do
+  describe '.build' do
+    subject(:build) { described_class.build(type, key, arg1, arg2) }
+
+    let(:type) { :type }
+    let(:key) { :key }
+    let(:arg1) { 'arg1' }
+    let(:arg2) { 'arg2' }
+    let(:klass) { nil }
+
+    before { allow(Industrialist::Registrar).to receive(:value_for).and_return(klass) }
+
+    it 'retrieves the class registered under the type and key' do
+      build
+      expect(Industrialist::Registrar).to have_received(:value_for).with(type, key)
+    end
+
+    context 'when the registrar returns nil' do
+      let(:klass) { nil }
+
+      it 'returns nil' do
+        expect(build).to be_nil
+      end
+    end
+
+    context 'when the registrar returns a class' do
+      let(:klass) { class Klass; end; Klass }
+      let(:instance) { instance_double(klass) }
+
+      before { allow(klass).to receive(:new).and_return(instance) }
+
+      it 'builds an instance of the class with the provided arguments' do
+        build
+        expect(klass).to have_received(:new).with(arg1, arg2)
+      end
+
+      it 'returns the instance' do
+        expect(build).to eq(instance)
+      end
+    end
+  end
+end

--- a/spec/lib/industrialist/config_spec.rb
+++ b/spec/lib/industrialist/config_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+RSpec.describe Industrialist::Config do
+  after { described_class.manufacturable_paths.clear }
+
+  describe '.manufacturable_paths' do
+    subject(:manufacturable_paths) { described_class.manufacturable_paths }
+
+    context 'when there are NO manufacturable paths' do
+      it 'returns an empty array' do
+        expect(manufacturable_paths).to eq([])
+      end
+    end
+
+    context 'when there are manufacturable paths' do
+      let(:path1) { 'path1' }
+      let(:path2) { 'path2' }
+
+      before do
+        manufacturable_paths << path1
+        manufacturable_paths << path2
+      end
+
+      it 'returns an array containing the manufacturable paths' do
+        expect(manufacturable_paths).to eq([path1, path2])
+      end
+    end
+  end
+
+  describe '.load_manufacturables' do
+    subject(:load_manufacturables) { described_class.load_manufacturables }
+
+    let(:path1_files) { [file1, file2] }
+    let(:path2_files) { [file3, file4] }
+    let(:file1) { 'file1' }
+    let(:file2) { 'file2' }
+    let(:file3) { 'file3' }
+    let(:file4) { 'file4' }
+    let(:path1) { 'path1' }
+    let(:path2) { 'path2' }
+
+    before do
+      described_class.manufacturable_paths << path1
+      described_class.manufacturable_paths << path2
+
+      allow(Dir).to receive(:[]).with("#{path1}/**/*.rb").and_return(path1_files)
+      allow(Dir).to receive(:[]).with("#{path2}/**/*.rb").and_return(path2_files)
+      described_class.require_method = require_method
+    end
+
+    context 'when a require method is NOT set' do
+      let(:require_method) { nil }
+
+      before do
+        allow(Kernel).to receive(:require)
+
+        load_manufacturables
+      end
+
+      it 'requires all files under all manufacturable paths' do
+        [file1, file2, file3, file4].each { |file| expect(Kernel).to have_received(:require).with(file) }
+      end
+    end
+
+    context 'when a require method is set' do
+      let(:require_method) { :require_dependency }
+
+      before do
+        allow(Kernel).to receive(require_method)
+
+        load_manufacturables
+      end
+
+      it 'requires all files under all manufacturable paths' do
+        [file1, file2, file3, file4].each { |file| expect(Kernel).to have_received(require_method).with(file) }
+      end
+    end
+  end
+end

--- a/spec/lib/industrialist/manufacturable_spec.rb
+++ b/spec/lib/industrialist/manufacturable_spec.rb
@@ -3,12 +3,10 @@ require 'spec_helper'
 RSpec.describe Industrialist::Manufacturable do
   before(:all) do
     class Automobile
-      include Industrialist::Manufacturable
-      create_factory :AutomobileFactory
+      extend Industrialist::Manufacturable
     end
     class Book
-      include Industrialist::Manufacturable
-      create_factory :BookFactory
+      extend Industrialist::Manufacturable
     end
   end
 
@@ -16,44 +14,11 @@ RSpec.describe Industrialist::Manufacturable do
     allow(Industrialist::WarningHelper).to receive(:warning).and_call_original
   end
 
-  describe '.included' do
-    let(:manufacturable_class) do
-      Class.new do
-        include Industrialist::Manufacturable
-        create_factory :AnimalFactory
-      end
-    end
+  describe '.extended' do
+    let(:industrialized_string) { :automobile }
 
-    context 'when the factory is NOT defined on the base class' do
-      before { manufacturable_class }
-
-      it 'does NOT warn' do
-        expect(Industrialist::WarningHelper).not_to have_received(:warning)
-      end
-    end
-
-    context 'when the factory is defined on the base class' do
-      let(:child_of_manufacturable_class) do
-        Class.new(manufacturable_class) do
-          include Industrialist::Manufacturable
-        end
-      end
-
-      before { child_of_manufacturable_class }
-
-      it 'warns' do
-        expect(Industrialist::WarningHelper).to have_received(:warning)
-      end
-    end
-  end
-
-  describe '.create_factory' do
-    it 'assigns the provided name to the factory instance' do
-      expect(AutomobileFactory).to be_an(Industrialist::Factory)
-    end
-
-    it 'assigns a different factory instance to each base class' do
-      expect(AutomobileFactory.object_id).not_to eq(BookFactory.object_id)
+    it 'sets a type on the factory' do
+      expect(Automobile.class_variable_get(:@@type)).to eq(industrialized_string)
     end
   end
 
@@ -71,15 +36,15 @@ RSpec.describe Industrialist::Manufacturable do
     end
 
     it 'registers the class under the provided key' do
-      expect(AutomobileFactory.registry[:sedan]).to equal(Sedan)
-      expect(AutomobileFactory.registry[:coupe]).to equal(Coupe)
-      expect(BookFactory.registry[:paperback]).to equal(Paperback)
+      expect(Industrialist.build(:automobile, :sedan)).to be_a(Sedan)
+      expect(Industrialist.build(:automobile, :coupe)).to be_a(Coupe)
+      expect(Industrialist.build(:book, :paperback)).to be_a(Paperback)
     end
 
     it 'does NOT register the class in other factories' do
-      expect(AutomobileFactory.registry[:paperback]).to be_nil
-      expect(BookFactory.registry[:sedan]).to be_nil
-      expect(BookFactory.registry[:coupe]).to be_nil
+      expect(Industrialist.build(:book, :sedan)).to be_nil
+      expect(Industrialist.build(:book, :coupe)).to be_nil
+      expect(Industrialist.build(:automobile, :paperback)).to be_nil
     end
   end
 
@@ -91,21 +56,7 @@ RSpec.describe Industrialist::Manufacturable do
     end
 
     it 'registers the class under the default key' do
-      expect(AutomobileFactory.registry[Industrialist::Factory::DEFAULT_KEY]).to equal(Sedan)
-    end
-
-    context 'when multiple defaults are registered with the same factory' do
-      let(:duplicative_default_class) do
-        class Coupe < Automobile
-          manufacturable_default
-        end
-      end
-
-      before { duplicative_default_class }
-
-      it 'warns' do
-        expect(Industrialist::WarningHelper).to have_received(:warning)
-      end
+      expect(Industrialist.build(:automobile, :clown_car)).to be_a(Sedan)
     end
   end
 end

--- a/spec/lib/industrialist/registrar_spec.rb
+++ b/spec/lib/industrialist/registrar_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+RSpec.describe Industrialist::Registrar do
+  let(:type) { :type }
+  let(:key) { :key }
+  let(:klass) { class_double('klass', name: 'Klass') }
+
+  after { described_class.instance_variable_get(:@registry).clear }
+
+  describe '.register' do
+    subject(:register) { described_class.register(type, key, klass) }
+
+    before { register }
+
+    it 'registers the class under the type and key' do
+      expect(described_class.value_for(type, key)).to be(klass)
+    end
+
+    context 'when the key is already defined for a different class' do
+      before do
+        allow(Industrialist::WarningHelper).to receive(:warning)
+
+        described_class.register(type, key, class_double('different_klass', name: 'Different'))
+      end
+
+      it 'warns' do
+        expect(Industrialist::WarningHelper).to have_received(:warning).with(described_class::REDEFINED_KEY_WARNING_MESSAGE)
+      end
+    end
+  end
+
+  describe '.register_default' do
+    subject(:register_default) { described_class.register_default(type, klass) }
+
+    let(:key) { described_class::DEFAULT_KEY }
+
+    before { register_default }
+
+    it 'registers the class under the type and default key' do
+      expect(described_class.value_for(type, key)).to be(klass)
+    end
+
+    context 'when the default key is already defined for a different class' do
+      before do
+        allow(Industrialist::WarningHelper).to receive(:warning)
+
+        described_class.register_default(type, class_double('different_klass', name: 'Different'))
+      end
+
+      it 'warns' do
+        expect(Industrialist::WarningHelper).to have_received(:warning).with(described_class::REDEFINED_DEFAULT_WARNING_MESSAGE)
+      end
+    end
+  end
+
+  describe '.value_for' do
+    context 'when the type is NOT registered' do
+      let(:type) { :unregistered_type }
+
+      it 'returns nil' do
+        expect(described_class.value_for(type, key)).to be_nil
+      end
+    end
+
+    context 'when the type is registered' do
+      let(:type) { :registered_type }
+
+      before { described_class.register(type, key, klass) }
+
+      context 'and the key is NOT registered' do
+        let(:accessed_key) { :unregistered_key }
+
+        context 'and there is NOT a class under the default key' do
+          it 'returns nil' do
+            expect(described_class.value_for(type, accessed_key)).to be_nil
+          end
+        end
+
+        context 'and there is a class under the default key' do
+          before { described_class.register_default(type, klass) }
+
+          it 'returns the class under the type and default key' do
+            expect(described_class.value_for(type, accessed_key)).to be(klass)
+          end
+        end
+      end
+
+      context 'and the key is registered' do
+        let(:accessed_key) { :registered_key }
+
+        before { described_class.register(type, accessed_key, klass) }
+
+        it 'returns the class under the type and key' do
+          expect(described_class.value_for(type, accessed_key)).to be(klass)
+        end
+      end
+    end
+  end
+
+  describe '.registered_types' do
+    subject(:registered_types) { described_class.registered_types }
+
+    let(:type1) { :type1 }
+    let(:type2) { :type2 }
+
+    before do
+      described_class.register(type1, key, klass)
+      described_class.register(type2, key, klass)
+    end
+
+    it 'returns the registered types' do
+      expect(registered_types).to eq([type1, type2])
+    end
+  end
+
+  describe '.registered_keys' do
+    subject(:registered_keys) { described_class.registered_keys(type) }
+
+    let(:key1) { :key1 }
+    let(:key2) { :key2 }
+
+    before do
+      described_class.register(type, key1, klass)
+      described_class.register(type, key2, klass)
+    end
+
+    it 'returns the registered types' do
+      expect(registered_keys).to eq([key1, key2])
+    end
+  end
+end

--- a/spec/lib/industrialist/type_spec.rb
+++ b/spec/lib/industrialist/type_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+RSpec.describe Industrialist::Type do
+  describe '.industrialize' do
+    subject(:industrialize) { described_class.industrialize(klass) }
+
+    let(:klass) { instance_double('klass', name: class_name) }
+
+    context 'when the class name is a single word' do
+      let(:class_name) { 'Word' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:word)
+      end
+    end
+
+    context 'when the class name is a word with a number at the end' do
+      let(:class_name) { 'Word1' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:word_1)
+      end
+    end
+
+    context 'when the class name is two words' do
+      let(:class_name) { 'TwoWords' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:two_words)
+      end
+    end
+
+    context 'when the class name is two words with a number in the middle' do
+      let(:class_name) { 'Two3Words' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:two_3_words)
+      end
+    end
+
+    context 'when the class name contains consecutive capital letters' do
+      let(:class_name) { 'LOUDWords' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:loud_words)
+      end
+    end
+
+    context 'when the class name contains consecutive numbers' do
+      let(:class_name) { 'Word123' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:word_123)
+      end
+    end
+
+    context 'when the class name contains consecutive capital letters and consecutive numbers' do
+      let(:class_name) { 'WORD123' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:word_123)
+      end
+    end
+
+    context 'when the class name contains underscores' do
+      let(:class_name) { 'Un_Der_Scöre' }
+
+      it 'industrializes the class name' do
+        expect(industrialize).to eq(:un_der_scöre)
+      end
+    end
+  end
+end

--- a/spec/lib/industrialist/warning_helper_spec.rb
+++ b/spec/lib/industrialist/warning_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Industrialist::WarningHelper do
+  describe '.warning' do
+    subject(:warning) { described_class.warning(message) }
+
+    let(:message) { 'Warning!' }
+    let(:call_stack) { ["file_name:line_number", "ignored", "ignored"] }
+
+    before do
+      allow(described_class).to receive(:caller).and_return(call_stack)
+      allow(described_class).to receive(:warn)
+
+      warning
+    end
+
+    it 'grabs the fourth item from the callstack' do
+      expect(described_class).to have_received(:caller).with(3..3)
+    end
+
+    it 'warns with the caller location inclding the line number' do
+      expect(described_class).to have_received(:warn).with(a_string_including("file_name:line_number"))
+    end
+
+    it 'warns with the supplied message' do
+      expect(described_class).to have_received(:warn).with(a_string_including(": #{message}"))
+    end
+  end
+end

--- a/spec/lib/industrialist_spec.rb
+++ b/spec/lib/industrialist_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe Industrialist do
+  describe '.config' do
+    before { allow(Industrialist::Config).to receive(:load_manufacturables) }
+
+    it 'yields Config the the provided block' do
+      expect { |b| described_class.config(&b) }.to yield_with_args(Industrialist::Config)
+    end
+
+    it 'delegates loading manufacturables to Config' do
+      described_class.config {}
+
+      expect(Industrialist::Config).to have_received(:load_manufacturables)
+    end
+  end
+
+  describe '.build' do
+    subject(:build) { described_class.build(arg1, arg2) }
+
+    let(:arg1) { :arg1 }
+    let(:arg2) { :arg2 }
+
+    before do
+      allow(Industrialist::Builder).to receive(:build)
+
+      build
+    end
+
+    it 'delegates build to Builder' do
+      expect(Industrialist::Builder).to have_received(:build).with(arg1, arg2)
+    end
+  end
+
+  describe '.registered_types' do
+    subject(:registered_types) { described_class.registered_types }
+
+    before do
+      allow(Industrialist::Registrar).to receive(:registered_types)
+
+      registered_types
+    end
+
+    it 'delegates registered_types to Registrar' do
+      expect(Industrialist::Registrar).to have_received(:registered_types)
+    end
+  end
+
+  describe '.registered_keys' do
+    subject(:registered_keys) { described_class.registered_keys(type) }
+
+    let(:type) { :type }
+
+    before do
+      allow(Industrialist::Registrar).to receive(:registered_keys)
+
+      registered_keys
+    end
+
+    it 'delegates registered_keys to Registrar' do
+      expect(Industrialist::Registrar).to have_received(:registered_keys).with(type)
+    end
+  end
+end


### PR DESCRIPTION

- Adds Registrar to manage manufacturable classes by type and key
- Adds Builder to manage retrieving and instantiating manufacturable classes
- Adds Config to facilitate loading manufacturables
- Adds Railtie to configure require method based on Rails eager_load config
- Adds Type to industrialize class names on registration
- Manufacturable base classes are assigned a type upon extending Manufacturable
- Extending Factory provides .manufactures and .build methods
- Adds example ruby app
- Updates README to reflect new API
- Bumps version to 1.0.0