### PR TITLE
Modifies Registrar to symbolize keys when possible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    industrialist (1.0.0)
+    industrialist (1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/industrialist/registrar.rb
+++ b/lib/industrialist/registrar.rb
@@ -11,7 +11,7 @@ module Industrialist
       def register(type, key, klass)
         WarningHelper.warning(REDEFINED_KEY_WARNING_MESSAGE) if overriding?(type, key, klass)
 
-        registry[type][key] = klass
+        registry[type][registry_key(key)] = klass
       end
 
       def register_default(type, klass)
@@ -23,7 +23,7 @@ module Industrialist
       def value_for(type, key)
         return unless registry.key?(type)
 
-        registry[type][key] || registry[type][DEFAULT_KEY]
+        registry[type][registry_key(key)] || registry[type][DEFAULT_KEY]
       end
 
       def registered_types
@@ -35,6 +35,10 @@ module Industrialist
       end
 
       private
+
+      def registry_key(key)
+        (key.respond_to?(:to_sym) && key.to_sym) || key
+      end
 
       def overriding?(type, key, klass)
         !registry[type][key].nil? && registry[type][key].name != klass.name

--- a/lib/industrialist/version.rb
+++ b/lib/industrialist/version.rb
@@ -1,3 +1,3 @@
 module Industrialist
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/lib/industrialist/registrar_spec.rb
+++ b/spec/lib/industrialist/registrar_spec.rb
@@ -10,17 +10,37 @@ RSpec.describe Industrialist::Registrar do
   describe '.register' do
     subject(:register) { described_class.register(type, key, klass) }
 
-    before { register }
+    context 'when the key can be symbolized' do
+      let(:key) { 'string_key' }
+      let(:symbolized_key) { :string_key }
 
-    it 'registers the class under the type and key' do
-      expect(described_class.value_for(type, key)).to be(klass)
+      before { register }
+
+      it 'registers the class under the type and symbolized key' do
+        expect(described_class.value_for(type, symbolized_key)).to be(klass)
+      end
+
+      it 'allows accessing the class under the type and  the original key' do
+        expect(described_class.value_for(type, key)).to be(klass)
+      end
+    end
+
+    context 'when the key cannot be symbolized' do
+      let(:key) { { key: :value } }
+
+      before { register }
+
+      it 'registers the class under the type and key' do
+        expect(described_class.value_for(type, key)).to be(klass)
+      end
     end
 
     context 'when the key is already defined for a different class' do
       before do
         allow(Industrialist::WarningHelper).to receive(:warning)
-
         described_class.register(type, key, class_double('different_klass', name: 'Different'))
+
+        register
       end
 
       it 'warns' do


### PR DESCRIPTION
- Registrar symbolizes keys when possible
- Adds test for using non-symbolizable objects as keys

Use case:
```ruby
class Automobile
  extend Industrialist::Manufacturable
end

class Coupe < Automobile
  corresponds_to :coupe
end

class AutomobileFactory
  extend Industrialist::Factory
  manufactures Automobile
end
```
Current behavior:
```ruby
AutomobileFactory.build(:coupe) # => #<Coupe:0x00007fb48604e010>
AutomobileFactory.build('coupe') # => nil
```
With these changes:
```ruby
AutomobileFactory.build(:coupe) # => #<Coupe:0x00007fb485147828>
AutomobileFactory.build('coupe') # => #<Coupe:0x00007fb4860454d8>
```